### PR TITLE
Dont modify redis read only lua tables

### DIFF
--- a/lib/qless-lib.lua
+++ b/lib/qless-lib.lua
@@ -33,7 +33,7 @@ QlessRecurringJob.__index = QlessRecurringJob
 Qless.config = {}
 
 -- Extend a table. This comes up quite frequently
-function table.extend(self, other)
+local function tbl_extend(self, other)
   for i, v in ipairs(other) do
     table.insert(self, v)
   end
@@ -1522,7 +1522,7 @@ function QlessQueue:peek(now, count)
 
   -- With these in place, we can expand this list of jids based on the work
   -- queue itself and the priorities therein
-  table.extend(jids, self.work.peek(count - #jids))
+  tbl_extend(jids, self.work.peek(count - #jids))
 
   return jids
 end
@@ -1597,7 +1597,7 @@ function QlessQueue:pop(now, worker, count)
 
   -- With these in place, we can expand this list of jids based on the work
   -- queue itself and the priorities therein
-  table.extend(jids, self.work.peek(count - #jids))
+  tbl_extend(jids, self.work.peek(count - #jids))
 
   local state
   for index, jid in ipairs(jids) do

--- a/lib/qless.lua
+++ b/lib/qless.lua
@@ -24,7 +24,7 @@ QlessRecurringJob.__index = QlessRecurringJob
 
 Qless.config = {}
 
-function table.extend(self, other)
+local function tbl_extend(self, other)
   for i, v in ipairs(other) do
     table.insert(self, v)
   end
@@ -1118,7 +1118,7 @@ function QlessQueue:peek(now, count)
 
   self:check_scheduled(now, count - #jids)
 
-  table.extend(jids, self.work.peek(count - #jids))
+  tbl_extend(jids, self.work.peek(count - #jids))
 
   return jids
 end
@@ -1167,7 +1167,7 @@ function QlessQueue:pop(now, worker, count)
 
   self:check_scheduled(now, count - #jids)
 
-  table.extend(jids, self.work.peek(count - #jids))
+  tbl_extend(jids, self.work.peek(count - #jids))
 
   local state
   for index, jid in ipairs(jids) do


### PR DESCRIPTION
It seems that Redis after version 6.2.7 doesn't allow us to modify global lua tables.
Probably added here: https://github.com/redis/redis/pull/10651

The following error happens:

```
2022/06/10 22:17:11 [error] 108#0: *51 [lua] qless.lua:343: call(): ERR user_script:27: Attempt to modify a read only table script: dbf8cd1bf81f9d8ad0ae8aa84860da676603dda4, on @user_script:27., context: ngx.timer
2022/06/10 22:17:11 [error] 108#0: *51 [lua] qless.lua:343: deregister_workers(): ERR user_script:27: Attempt to modify a readonly table script: dbf8cd1bf81f9d8ad0ae8aa84860da676603dda4, on @user_script:27., context: ngx.timer
```

The line 27 is changing the table "table".
However it was required to make the function local to make the error stop.
It seems that this won't break for previous of Redis.

A new tag at luarocks would be appreciated, so Dockerfiles can run properly again.
https://luarocks.org/modules/pintsized/lua-resty-qless

Thanks!